### PR TITLE
Feature/add tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,14 +4,9 @@
 
 root = true
 
-
 [*]
-
-# Change these settings to your own preference
 indent_style = space
 indent_size = 2
-
-# We recommend you to keep these unchanged
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: true
+git:
+  depth: 10
+branches:
+  only:
+    - master
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+os: osx
+
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 0.6.0
+- Tests! Specs for sass and scss.
+- Added Travis, CircleCi & Appveyor builds
+
+### 0.5.1
+- Added contribution guidelines
+- Added .editorconfig for consistent contributions [http://editorconfig.org/](http://editorconfig.org/)
+- Updated executablePath option description
+- Updated project description
+- Added missing documentation for noConfigDisable option
+
 ### 0.5.0
 - Improved error messages
 - Added option to disable linting if no config file is found

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,18 @@
+version: "{build}"
+os: Windows Server 2012 R2
+branches:
+  only:
+    - master
+test: off
+deploy: off
+
+install:
+  - appveyor DownloadFile https://atom.io/download/windows -FileName AtomSetup.exe
+  - AtomSetup.exe /silent
+
+build_script:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - SET PATH=%LOCALAPPDATA%\atom\bin;%PATH%
+  - apm clean
+  - apm install
+  - apm test

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,18 @@
+dependencies:
+  pre:
+    # Force updating wget due to the current containers being too out of date
+    - sudo apt-get update
+    - sudo apt-get install wget
+  override:
+    - wget -O atom-amd64.deb https://atom.io/download/deb
+    # - sudo apt-get update # Cut out until wget is fixed on the containers
+    - sudo dpkg --install atom-amd64.deb || true
+    - sudo apt-get -f install -y
+    - apm install
+test:
+  override:
+    - atom -v
+    - apm -v
+    - ./node_modules/.bin/coffeelint lib
+    - ./node_modules/.bin/eslint spec
+    - apm test

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "linter"
   ],
   "scripts": {
-    "lint": ".coffeelint ./lib/main.coffee"
+    "lint": "coffeelint ./lib/main.coffee"
   },
   "engines": {
     "atom": ">=1.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "linter"
   ],
   "scripts": {
-    "lint": "./node_modules/.bin/coffeelint ./lib/main.coffee"
+    "lint": ".coffeelint ./lib/main.coffee"
   },
   "engines": {
     "atom": ">=1.0.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "linter"
   ],
   "scripts": {
-    "test": "coffeelint ./lib/main.coffee"
+    "lint": "./node_modules/.bin/coffeelint ./lib/main.coffee"
   },
   "engines": {
     "atom": ">=1.0.0"
@@ -34,6 +34,20 @@
     }
   },
   "devDependencies": {
-    "coffeelint": "^1.14.2"
+    "babel-eslint": "^4.1.6",
+    "coffeelint": "^1.14.2",
+    "eslint": "^1.10.3",
+    "eslint-config-airbnb": "^2.1.1"
+  },
+  "eslintConfig": {
+    "extends": "airbnb/base",
+    "parser": "babel-eslint",
+    "globals": {
+      "atom": true
+    },
+    "env": {
+      "es6": true,
+      "node": true
+    }
   }
 }

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "globals": {
+    "waitsForPromise": true
+  },
+  "env": {
+    "jasmine": true
+  }
+}

--- a/spec/fixtures/config/.sass-lint.yml
+++ b/spec/fixtures/config/.sass-lint.yml
@@ -1,0 +1,8 @@
+options:
+  formatter: json
+  merge-default-rules: false
+files:
+  include: '**/*.s+(a|c)ss'
+rules:
+  no-color-literals: 1
+  no-ids: 2

--- a/spec/fixtures/files/failure.sass
+++ b/spec/fixtures/files/failure.sass
@@ -1,0 +1,2 @@
+#test
+  color: red

--- a/spec/fixtures/files/failure.scss
+++ b/spec/fixtures/files/failure.scss
@@ -1,0 +1,3 @@
+#test {
+  color: red;
+}

--- a/spec/fixtures/files/pass.sass
+++ b/spec/fixtures/files/pass.sass
@@ -1,0 +1,4 @@
+$var-red: red
+
+.test
+  color: $red

--- a/spec/fixtures/files/pass.scss
+++ b/spec/fixtures/files/pass.scss
@@ -1,0 +1,5 @@
+$var-red: red;
+
+.test {
+  color: $red;
+}

--- a/spec/linter-sass-lint-sass-spec.js
+++ b/spec/linter-sass-lint-sass-spec.js
@@ -1,0 +1,76 @@
+'use babel';
+
+describe('The scss_lint provider for Linter - scss', () => {
+  const lint = require('../lib/main').provideLinter().lint;
+  const configFile = __dirname + '/fixtures/config/.sass-lint.yml';
+
+  beforeEach(() => {
+    atom.workspace.destroyActivePaneItem();
+    waitsForPromise(() => {
+      atom.packages.activatePackage('linter-sass-lint');
+      return atom.packages.activatePackage('language-sass').then(() =>
+        atom.workspace.open(__dirname + '/fixtures/clean.scss')
+      );
+    });
+  });
+
+  describe('checks failure.scss and', () => {
+    let editor = null;
+    beforeEach(() => {
+      waitsForPromise(() => {
+        atom.config.set('linter-sass-lint.configPath', configFile);
+        return atom.workspace.open(__dirname + '/fixtures/files/failure.scss').then(openEditor => {
+          editor = openEditor;
+        });
+      });
+    });
+
+    it('finds at least one message', () => {
+      const messages = lint(editor);
+      expect(messages.length).toBeGreaterThan(0);
+    });
+
+    it('verifies the first message', () => {
+      const messages = lint(editor);
+      expect(messages[0].type).toBeDefined();
+      expect(messages[0].type).toEqual('Error');
+      expect(messages[0].html).toBeDefined();
+      expect(messages[0].html).toEqual('<span class=\"badge badge-flexible\">no-ids</span> ID selectors not allowed');
+      expect(messages[0].filePath).toBeDefined();
+      expect(messages[0].filePath).toMatch(/.+failure\.scss$/);
+      expect(messages[0].range).toBeDefined();
+      expect(messages[0].range.length).toEqual(2);
+      expect(messages[0].range).toEqual([[0, 0], [0, 1]]);
+    });
+
+    it('verifies the second message', () => {
+      const messages = lint(editor);
+      expect(messages[1].type).toBeDefined();
+      expect(messages[1].type).toEqual('Warning');
+      expect(messages[1].html).toBeDefined();
+      expect(messages[1].html).toEqual('<span class=\"badge badge-flexible\">no-color-literals</span> Color literals such as \'red\' should only be used in variable declarations');
+      expect(messages[1].filePath).toBeDefined();
+      expect(messages[1].filePath).toMatch(/.+failure\.scss$/);
+      expect(messages[1].range).toBeDefined();
+      expect(messages[1].range.length).toEqual(2);
+      expect(messages[1].range).toEqual([[1, 9], [1, 10]]);
+    });
+  });
+
+  describe('checks pass.scss and', () => {
+    let editor = null;
+    beforeEach(() => {
+      waitsForPromise(() => {
+        atom.config.set('linter-sass-lint.configPath', configFile);
+        return atom.workspace.open(__dirname + '/fixtures/files/pass.scss').then(openEditor => {
+          editor = openEditor;
+        });
+      });
+    });
+
+    it('finds nothing wrong with the valid file', () => {
+      const messages = lint(editor);
+      expect(messages.length).toEqual(0);
+    });
+  });
+});

--- a/spec/linter-sass-lint-scss-spec.js
+++ b/spec/linter-sass-lint-scss-spec.js
@@ -1,0 +1,76 @@
+'use babel';
+
+describe('The scss_lint provider for Linter - sass', () => {
+  const lint = require('../lib/main').provideLinter().lint;
+  const configFile = __dirname + '/fixtures/config/.sass-lint.yml';
+
+  beforeEach(() => {
+    atom.workspace.destroyActivePaneItem();
+    waitsForPromise(() => {
+      atom.packages.activatePackage('linter-sass-lint');
+      return atom.packages.activatePackage('language-sass').then(() =>
+        atom.workspace.open(__dirname + '/fixtures/clean.scss')
+      );
+    });
+  });
+
+  describe('checks failure.sass and', () => {
+    let editor = null;
+    beforeEach(() => {
+      waitsForPromise(() => {
+        atom.config.set('linter-sass-lint.configPath', configFile);
+        return atom.workspace.open(__dirname + '/fixtures/files/failure.sass').then(openEditor => {
+          editor = openEditor;
+        });
+      });
+    });
+
+    it('finds at least one message', () => {
+      const messages = lint(editor);
+      expect(messages.length).toBeGreaterThan(0);
+    });
+
+    it('verifies the first message', () => {
+      const messages = lint(editor);
+      expect(messages[0].type).toBeDefined();
+      expect(messages[0].type).toEqual('Error');
+      expect(messages[0].html).toBeDefined();
+      expect(messages[0].html).toEqual('<span class=\"badge badge-flexible\">no-ids</span> ID selectors not allowed');
+      expect(messages[0].filePath).toBeDefined();
+      expect(messages[0].filePath).toMatch(/.+failure\.sass$/);
+      expect(messages[0].range).toBeDefined();
+      expect(messages[0].range.length).toEqual(2);
+      expect(messages[0].range).toEqual([[0, 0], [0, 1]]);
+    });
+
+    it('verifies the second message', () => {
+      const messages = lint(editor);
+      expect(messages[1].type).toBeDefined();
+      expect(messages[1].type).toEqual('Warning');
+      expect(messages[1].html).toBeDefined();
+      expect(messages[1].html).toEqual('<span class=\"badge badge-flexible\">no-color-literals</span> Color literals such as \'red\' should only be used in variable declarations');
+      expect(messages[1].filePath).toBeDefined();
+      expect(messages[1].filePath).toMatch(/.+failure\.sass$/);
+      expect(messages[1].range).toBeDefined();
+      expect(messages[1].range.length).toEqual(2);
+      expect(messages[1].range).toEqual([[1, 9], [1, 10]]);
+    });
+  });
+
+  describe('checks pass.sass and', () => {
+    let editor = null;
+    beforeEach(() => {
+      waitsForPromise(() => {
+        atom.config.set('linter-sass-lint.configPath', configFile);
+        return atom.workspace.open(__dirname + '/fixtures/files/pass.sass').then(openEditor => {
+          editor = openEditor;
+        });
+      });
+    });
+
+    it('finds nothing wrong with the valid file', () => {
+      const messages = lint(editor);
+      expect(messages.length).toEqual(0);
+    });
+  });
+});


### PR DESCRIPTION
* Adds travis.yml file
* gitattributes file to enforce line endings
* quick cleanup of my existing editorconfig
* specs for both sass and scss file formats
* dummy config file

shamelessly relied on linter-eslint and linter-scss-lint for the bulk of the ideas here and a leg up in getting the tests of the ground.