### PR TITLE
Fix ignored files for lint on fly

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -89,8 +89,9 @@ module.exports =
 
         try
           compiledConfig = linter.getConfig({}, config)
+          relativePath = this.getFilePath(filePath)[1]
 
-          if globule.isMatch(compiledConfig.files.include, this.getFilePath(filePath)[1]) and not globule.isMatch(compiledConfig.files.ignore, this.getFilePath(filePath)[1])
+          if globule.isMatch(compiledConfig.files.include, relativePath) and not globule.isMatch(compiledConfig.files.ignore, relativePath)
             result = linter.lintText({
               text: editor.getText(),
               format: path.extname(filePath).slice(1),

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -9,8 +9,8 @@ module.exports =
       title: 'Disable when no sass-lint config file is found in your project and a .sass-lint.yml file is not specified in the .sass-lint.yml Path option'
       type: 'boolean'
       default: false
-    configPath:
-      title: '.sass-lint.yml Path'
+    configFile:
+      title: '.sass-lint.yml Config File'
       description: 'A .sass-lint.yml file to use/fallback to if no config file is found in the current project root'
       type: 'string'
       default: ''
@@ -29,9 +29,9 @@ module.exports =
     @subs.add atom.config.observe 'linter-sass-lint.noConfigDisable',
       (noConfigDisable) =>
         @noConfigDisable = noConfigDisable
-    @subs.add atom.config.observe 'linter-sass-lint.configPath',
-      (configPath) =>
-        @configPath = configPath
+    @subs.add atom.config.observe 'linter-sass-lint.configFile',
+      (configFile) =>
+        @configFile = configFile
     @subs.add atom.config.observe 'linter-sass-lint.executablePath',
       (executablePath) =>
         @executablePath = executablePath
@@ -49,7 +49,7 @@ module.exports =
         configExt = '.sass-lint.yml'
         filePath = editor.getPath()
         projectConfig = find filePath, configExt
-        globalConfig = if @configPath is '' then null else @configPath
+        globalConfig = if @configFile is '' then null else @configFile
         config = if projectConfig isnt null then projectConfig else globalConfig
 
         try
@@ -64,14 +64,11 @@ module.exports =
           return []
 
         if config isnt null and path.extname(config) isnt '.yml'
-          config = path.join @configPath, configExt
           atom.notifications.addWarning """
-            **Deprecation Warning**
+            **Config File Error**
 
-            As of `1.0.0` the configPath option will require you to
-            explicitly specify a .sass-lint.yml file rather than just a path to search.
-
-            Please add the full path and filename to this plugins configPath option.
+            The config file you specified doesn't seem to be a .yml file.\n
+            Please see the sass-lint [documentation](https://github.com/sasstools/sass-lint/tree/master/docs) on how to create a config file.
           """
 
         if config is null and @noConfigDisable is false

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "atom-linter": "^4.1.1",
     "atom-package-deps": "^3.0.6",
+    "globule": "^0.2.0",
     "sass-lint": "^1.4.0"
   },
   "package-deps": [

--- a/spec/linter-sass-lint-sass-spec.js
+++ b/spec/linter-sass-lint-sass-spec.js
@@ -18,7 +18,7 @@ describe('The scss_lint provider for Linter - sass', () => {
     let editor = null;
     beforeEach(() => {
       waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configPath', configFile);
+        atom.config.set('linter-sass-lint.configFile', configFile);
         return atom.workspace.open(__dirname + '/fixtures/files/failure.sass').then(openEditor => {
           editor = openEditor;
         });
@@ -65,7 +65,7 @@ describe('The scss_lint provider for Linter - sass', () => {
     let editor = null;
     beforeEach(() => {
       waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configPath', configFile);
+        atom.config.set('linter-sass-lint.configFile', configFile);
         return atom.workspace.open(__dirname + '/fixtures/files/pass.sass').then(openEditor => {
           editor = openEditor;
         });

--- a/spec/linter-sass-lint-scss-spec.js
+++ b/spec/linter-sass-lint-scss-spec.js
@@ -18,7 +18,7 @@ describe('The scss_lint provider for Linter - scss', () => {
     let editor = null;
     beforeEach(() => {
       waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configPath', configFile);
+        atom.config.set('linter-sass-lint.configFile', configFile);
         return atom.workspace.open(__dirname + '/fixtures/files/failure.scss').then(openEditor => {
           editor = openEditor;
         });
@@ -65,7 +65,7 @@ describe('The scss_lint provider for Linter - scss', () => {
     let editor = null;
     beforeEach(() => {
       waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configPath', configFile);
+        atom.config.set('linter-sass-lint.configFile', configFile);
         return atom.workspace.open(__dirname + '/fixtures/files/pass.scss').then(openEditor => {
           editor = openEditor;
         });


### PR DESCRIPTION
sass-lint's `lint-text` method doesn't handle ignored files so we handle it within the plugin. This fixes those issues.