### PR TITLE
Update to use included or global sass-lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ git:
 branches:
   only:
     - master
+before_script: npm install -g sass-lint
 notifications:
   email:
     on_success: never

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ deploy: off
 
 install:
   - appveyor DownloadFile https://atom.io/download/windows -FileName AtomSetup.exe
+  - npm install -g sass-lint
   - AtomSetup.exe /silent
 
 build_script:

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ dependencies:
     # - sudo apt-get update # Cut out until wget is fixed on the containers
     - sudo dpkg --install atom-amd64.deb || true
     - sudo apt-get -f install -y
+    - npm install -g sass-lint
     - apm install
 test:
   override:

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,9 +2,11 @@
 {find} = helpers = require 'atom-linter'
 path = require 'path'
 globule = require 'globule'
-ChildProcess = require('child_process')
+ChildProcess = require 'child_process'
+{getPath} = require 'consistent-path'
+env = Object.assign({}, process.env)
+
 prefixPath = null
-fixPath = require 'fix-path'
 
 module.exports =
   config:
@@ -64,11 +66,13 @@ module.exports =
       npmCommand = if process.platform is 'win32' then 'npm.cmd' else 'npm'
       try
         # Atom on OSX doesn't inherit a users PATH unless opened from the command line
-        if process.platform isnt 'win32' then fixPath()
+        if process.platform isnt 'win32'
+        then env = Object.assign({}, process.env, {PATH: getPath()})
+
         prefixPath = ChildProcess.spawnSync('npm', [
           'get'
           'prefix'
-        ]).output[1].toString().trim()
+        ], {env}).output[1].toString().trim()
       catch e
         throw new Error('prefix')
     if process.platform is 'win32'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -69,7 +69,7 @@ module.exports =
         if process.platform isnt 'win32'
         then env = Object.assign({}, process.env, {PATH: getPath()})
 
-        prefixPath = ChildProcess.spawnSync('npm', [
+        prefixPath = ChildProcess.spawnSync(npmCommand, [
           'get'
           'prefix'
         ], {env}).output[1].toString().trim()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,10 +2,9 @@
 {find} = helpers = require 'atom-linter'
 path = require 'path'
 globule = require 'globule'
-ChildProcess = require 'child_process'
+{spawnSync} = require 'child_process'
 {getPath} = require 'consistent-path'
-env = Object.assign({}, process.env)
-
+env = Object.assign({}, process.env, {PATH: getPath()})
 prefixPath = null
 
 module.exports =
@@ -65,11 +64,7 @@ module.exports =
     if @globalPath is '' and prefixPath is null
       npmCommand = if process.platform is 'win32' then 'npm.cmd' else 'npm'
       try
-        # Atom on OSX doesn't inherit a users PATH unless opened from the command line
-        if process.platform isnt 'win32'
-        then env = Object.assign({}, process.env, {PATH: getPath()})
-
-        prefixPath = ChildProcess.spawnSync(npmCommand, [
+        prefixPath = spawnSync(npmCommand, [
           'get'
           'prefix'
         ], {env}).output[1].toString().trim()
@@ -98,17 +93,18 @@ module.exports =
           if error.message is 'prefix' then atom.notifications.addError """
             **Error getting $PATH - linter-sass-lint**\n
 
-            You've enabled using global sass-lint without specifying a prefix so we tried.
-            Unfortunately we were unable to execute `npm get prefix` for you\n
-            Please make sure Atom is getting $PATH correctly or set it directly in linter-sass-lint settings
+            You've enabled using global sass-lint without specifying a prefix so we tried to.
+            Unfortunately we were unable to execute `npm get prefix` for you..\n
+            Please make sure Atom is getting $PATH correctly or set it directly in the `linter-sass-lint` settings.
           """, {dismissable: true}
           return []
 
           atom.notifications.addWarning """
             **Sass-lint package missing**
 
-            The sass-lint package cannot be found, please check sass-lint package path option of this package. \n
-            If you leave this option empty the sass-lint package included with linter-sass-lint will be used.
+            The sass-lint package cannot be found, please check sass-lint is installed globally. \n
+            You can always use the sass-lint pacakage included with linter-sass-lint by disabling the
+            `Use global sass-lint installation` option
           """, {dismissable: true}
           return []
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "atom-linter": "^4.1.1",
     "atom-package-deps": "^3.0.6",
-    "fix-path": "^1.1.0",
+    "consistent-path": "^1.0.3",
     "globule": "^0.2.0",
     "sass-lint": "^1.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "atom-linter": "^4.1.1",
     "atom-package-deps": "^3.0.6",
+    "fix-path": "^1.1.0",
     "globule": "^0.2.0",
     "sass-lint": "^1.4.0"
   },

--- a/spec/linter-sass-lint-path-options-spec.js
+++ b/spec/linter-sass-lint-path-options-spec.js
@@ -1,6 +1,6 @@
 'use babel';
 
-describe('The sass-lint provider for Linter - sass', () => {
+describe('The sass-lint provider for Linter - path options', () => {
   const lint = require('../lib/main').provideLinter().lint;
   const configFile = __dirname + '/fixtures/config/.sass-lint.yml';
 
@@ -12,18 +12,19 @@ describe('The sass-lint provider for Linter - sass', () => {
     });
   });
 
-  describe('checks failure.sass and', () => {
+  describe('checks failure.scss, expects a message and', () => {
     let editor = null;
     beforeEach(() => {
       waitsForPromise(() => {
         atom.config.set('linter-sass-lint.configFile', configFile);
-        return atom.workspace.open(__dirname + '/fixtures/files/failure.sass').then(openEditor => {
+        atom.config.set('linter-sass-lint.globalSassLint', true);
+        return atom.workspace.open(__dirname + '/fixtures/files/failure.scss').then(openEditor => {
           editor = openEditor;
         });
       });
     });
 
-    it('finds at least one message', () => {
+    it('lints the file with the globally installed sass-lint', () => {
       const messages = lint(editor);
       expect(messages.length).toBeGreaterThan(0);
     });
@@ -37,7 +38,7 @@ describe('The sass-lint provider for Linter - sass', () => {
       expect(messages[0].html).toBeDefined();
       expect(messages[0].html).toEqual(`${warningMarkup}${warnId}`);
       expect(messages[0].filePath).toBeDefined();
-      expect(messages[0].filePath).toMatch(/.+failure\.sass$/);
+      expect(messages[0].filePath).toMatch(/.+failure\.scss$/);
       expect(messages[0].range).toBeDefined();
       expect(messages[0].range.length).toEqual(2);
       expect(messages[0].range).toEqual([[0, 0], [0, 1]]);
@@ -52,62 +53,10 @@ describe('The sass-lint provider for Linter - sass', () => {
       expect(messages[1].html).toBeDefined();
       expect(messages[1].html).toEqual(`${warningMarkup}${warnId}`);
       expect(messages[1].filePath).toBeDefined();
-      expect(messages[1].filePath).toMatch(/.+failure\.sass$/);
+      expect(messages[1].filePath).toMatch(/.+failure\.scss$/);
       expect(messages[1].range).toBeDefined();
       expect(messages[1].range.length).toEqual(2);
       expect(messages[1].range).toEqual([[1, 9], [1, 10]]);
-    });
-  });
-
-  describe('checks pass.sass and', () => {
-    let editor = null;
-    beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configFile', configFile);
-        return atom.workspace.open(__dirname + '/fixtures/files/pass.sass').then(openEditor => {
-          editor = openEditor;
-        });
-      });
-    });
-
-    it('finds nothing wrong with the valid file', () => {
-      const messages = lint(editor);
-      expect(messages.length).toEqual(0);
-    });
-  });
-
-  describe('opens ignored.sass and', () => {
-    let editor = null;
-    beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configFile', configFile);
-        return atom.workspace.open(__dirname + '/fixtures/files/ignored.sass').then(openEditor => {
-          editor = openEditor;
-        });
-      });
-    });
-
-    it('ignores the file and reports no warnings', () => {
-      const messages = lint(editor);
-      expect(messages.length).toEqual(0);
-    });
-  });
-
-  describe('opens failure.sass and sets pacakage to not lint if no config file present', () => {
-    let editor = null;
-    beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.noConfigDisable', true);
-        atom.config.set('linter-sass-lint.configFile', '');
-        return atom.workspace.open(__dirname + '/fixtures/files/failure.sass').then(openEditor => {
-          editor = openEditor;
-        });
-      });
-    });
-
-    it('doesn\'t lint the file as there\s no config file present', () => {
-      const messages = lint(editor);
-      expect(messages.length).toEqual(0);
     });
   });
 });

--- a/spec/linter-sass-lint-scss-spec.js
+++ b/spec/linter-sass-lint-scss-spec.js
@@ -1,6 +1,6 @@
 'use babel';
 
-describe('The scss_lint provider for Linter - scss', () => {
+describe('The sass-lint provider for Linter - scss', () => {
   const lint = require('../lib/main').provideLinter().lint;
   const configFile = __dirname + '/fixtures/config/.sass-lint.yml';
 


### PR DESCRIPTION
Borrowing fairly heavily from linter-eslint on the advice of @Arcanemagus in #3 I've updated linter-sass-lint to use either the `sass-lint` packaged with this plugin or a users globally installed sass-lint borrowing some of the tricks as mentioned to determine the users PATH etc if not specified.

Closes #3 

still to do 
- [x] investigate specs