### PR TITLE
Prevent on lint parse errors on empty files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.0.3
+- Unexpected parse errors and sass-lint issues are just reported as lint errors rather than the annoying red box of doom
+- this will be updated in 1.1.0 to improve the way these are reported and handled, for now the errors will be logged to the console.
+
 ### 1.0.2
 - Update eslint-config-airbnb to version 4.0.0
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -154,14 +154,14 @@ module.exports =
               range: [[lineIdx, 0], [lineIdx, colEndIdx]]
             ]
           else
-            atom.notifications.addError """
-              **sass-lint had a problem**
-              Please consider filing an issue with [linter-sass-lint](https://github.com/AtomLinter/linter-sass-lint)
-              or [sass-lint](https://github.com/sasstools/sass-lint) including the text below and any other
-              information possible.
-
-              #{error.stack}
-            """, {dismissable: true}
+            # Leaving this here to allow people to report the errors
+            console.log(error.stack)
+            return [
+              type: 'Error'
+              text: 'Unexpected parse error in file'
+              filePath: filePath
+              range: [[lineIdx, 0], [lineIdx, colEndIdx]]
+            ]
           return []
 
         if result then return result.messages.map (msg) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -155,7 +155,7 @@ module.exports =
             ]
           else
             # Leaving this here to allow people to report the errors
-            console.log(error.stack)
+            console.log('linter-sass-lint', error)
             return [
               type: 'Error'
               text: 'Unexpected parse error in file'


### PR DESCRIPTION
On the fly linting has opened up a few issues with our parser, being the reason i avoided on the fly in the first place. This change just throws an unexpected token in file lint warning rather than the message that sass-lint had crashed as before