### PR TITLE
Remove error popup for no config

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -121,7 +121,7 @@ module.exports =
             type: 'Info'
             text: 'No .sass-lint.yml config file detected or specified. Please check your settings'
             filePath: filePath
-            range: [0, 0]
+            range: [[0, 0], [0, 0]]
           ]
 
         else if config is null and @noConfigDisable is true

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -117,13 +117,12 @@ module.exports =
           """
 
         if config is null and @noConfigDisable is false
-          atom.notifications.addError """
-            **No .sass-lint.yml config file found.** You can find an example of one
-            [here](https://github.com/sasstools/sass-lint/blob/master/lib/config/sass-lint.yml)
-            and documentation on how to configure this and each of the rules
-            [here](https://github.com/sasstools/sass-lint/tree/master/docs).
-          """
-          return []
+          return [
+            type: 'Info'
+            text: 'No .sass-lint.yml config file detected or specified. Please check your settings'
+            filePath: filePath
+            range: [0, 0]
+          ]
 
         else if config is null and @noConfigDisable is true
           return []


### PR DESCRIPTION
Removes the annoying error popup when no config file is found in the root of the project, specified in the global config settings and the option to disable linting when no config file is set to false. Replaces it with a lint warning of the type 'Info'.

Closes #26 