### PR TITLE
Switch to consistent-env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,42 @@
-sudo: true
-git:
-  depth: 10
-branches:
-  only:
-    - master
-before_script: npm install -g sass-lint
+# Project specific config
+os: linux
+language: node_js
+node_js:
+  - "0.8"
+  - "0.10"
+  - "0.11"
+  - "0.12"
+  - "4"
+  - "5"
+    # - os: osx
+    #   before_install:
+    #     - brew update
+    #     - brew outdated node || brew upgrade node
+
+install:
+  - npm install -g sass-lint
+
+# Generic setup follows
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+
 notifications:
   email:
     on_success: never
     on_failure: change
-os: osx
 
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+git:
+  depth: 10
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot
+
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,37 @@
-# Project specific config
-os: linux
-language: node_js
-node_js:
-  - "0.8"
-  - "0.10"
-  - "0.11"
-  - "0.12"
-  - "4"
-  - "5"
-    # - os: osx
-    #   before_install:
-    #     - brew update
-    #     - brew outdated node || brew upgrade node
+---
+os: osx
+sudo: true
+# lie to make travis work with nvm on osx
+language: cpp
+env:
+  matrix:
+    - TRAVIS_NODE_VERSION="0.10"
+    - TRAVIS_NODE_VERSION="0.12"
+    - TRAVIS_NODE_VERSION="2"
+    - TRAVIS_NODE_VERSION="4"
+    - TRAVIS_NODE_VERSION="5"
 
 install:
-  - npm install -g sass-lint
-
-# Generic setup follows
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
-
-notifications:
-  email:
-    on_success: never
-    on_failure: change
-
-git:
-  depth: 10
-
-sudo: false
-
-addons:
-  apt:
-    packages:
-    - build-essential
-    - git
-    - libgnome-keyring-dev
-    - fakeroot
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
+  - PATH="`npm bin`:`npm bin -g`:$PATH"
+  # Install dependencies and build
+  - npm install
 
 branches:
   only:
     - master
+
+git:
+  depth: 10
+
+notifications:
+  email:
+    on_failure: change
+    on_success: never
+
+before_script: "npm install -g sass-lint"
+
+script:
+  - node --version
+  - npm --version
+  - "curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh"

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -55,7 +55,7 @@ module.exports =
   # or the users globally installed sass-lint version
   findExecutable: ->
     {spawnSync} = require 'child_process'
-    {getPath} = require 'consistent-path'
+    consistentEnv = require 'consistent-env'
     if not @globalSassLint
       return require path.join(__dirname, '..', 'node_modules', 'sass-lint')
     if @globalPath is '' and prefixPath is null

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -60,7 +60,7 @@ module.exports =
       return require path.join(__dirname, '..', 'node_modules', 'sass-lint')
     if @globalPath is '' and prefixPath is null
       npmCommand = if process.platform is 'win32' then 'npm.cmd' else 'npm'
-      env = Object.assign({}, process.env, {PATH: getPath()})
+      env = Object.assign({}, consistentEnv())
       try
         prefixPath = spawnSync(npmCommand, [
           'get'

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "atom-linter": "^4.1.1",
     "atom-package-deps": "4.0.1",
-    "consistent-path": "1.0.3",
+    "consistent-env": "^1.0.1",
     "globule": "^0.2.0",
     "sass-lint": "^1.5.0"
   },


### PR DESCRIPTION
We aren't using `consistent-path`, and as it's just a wrapper around `consistent-env` anyway, use that directly.

Closes #49.