### PR TITLE
Lock eslint to version 2.2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.1.2
+- Lock down eslint to 2.2.x due to [eslint #5476](https://github.com/eslint/eslint/issues/5476)
+
 ### 1.1.1
 - Updated eslint to ^2.2.0
 - Updated eslint-config-airbnb to ^6.0.1

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "babel-eslint": "^5.0.0",
     "coffeelint": "^1.14.2",
-    "eslint": "^2.2.0",
+    "eslint": "2.2.x",
     "eslint-config-airbnb": "^6.0.1"
   },
   "eslintConfig": {


### PR DESCRIPTION
Due toe the missing dependency and hot patching going on with eslint babel-eslint we're locking eslint at version 2.2.x