### PR TITLE
Update sass-lint dependency to force updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.4.1
+- Update included version of sass-lint to 1.6.0 :tada:
+
 ## 1.4.0
 - Updated eslint and globule dependencies
 - Added links to the sass-lint rule documentation on all rule id badges/lint messages

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-sass-lint",
   "main": "./lib/main",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Atom Linter plugin to lint your Sass/SCSS with pure node sass-lint",
   "repository": "https://github.com/AtomLinter/linter-sass-lint",
   "license": "MIT",
@@ -23,7 +23,7 @@
     "atom-package-deps": "4.0.1",
     "consistent-env": "^1.0.1",
     "globule": "^1.0.0",
-    "sass-lint": "^1.5.0"
+    "sass-lint": "^1.6.0"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
Updates sass-lint for the new 1.6.0 version that we just released.
