### PR TITLE
prepare 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.3
+- Force latest version of sass-lint 1.7.0
+- Update a few dependencies
+
 ## 1.4.2
 - Include latest version of sass-lint
 - Fix dependency issue with eslint-config-airbnb-base

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "atom-package-deps": "4.0.1",
     "consistent-env": "^1.0.1",
     "globule": "^1.0.0",
-    "sass-lint": "^1.6.2"
+    "sass-lint": "^1.7.0"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
Sass-lint 1.7.0 included a few AST fixes and small regression fixes that I'm keen to make sure everyone has, had a few issues raised today due to the legacy version of sass-lint present.


