### PR TITLE
Add helper tests constants and support extra syntaxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.0
+- Allows the inclusion of files with extra extensions such as 'file.scss.liquid'
+- Updated to Atom linter ^5.0.1
+- Includes eslint updates for development
+
 ## 1.4.3
 - Force latest version of sass-lint 1.7.0
 - Update a few dependencies

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ There are three options you can configure either within the plugin or by editing
 
 * `globalSassLint` This allows you to specify that you want to use your globally installed version of `sass-lint` (`npm install -g sass-lint`) instead of the version bundled with `linter-sass-lint`.
 
+### Extra File Extensions
+
+This plugin will attempt to lint a file with framework specific file extensions on top of the usual `.scss` and `.sass` extensions such as with shopify's `.scss.liquid` extension as long as you still include `.scss` or `.sass` somewhere in the file, you must also ensure that the Atom grammar scope for that file is set to either SCSS or Sass depending on which it corresponds to.
+
+This does not mean that sass-lint will be able to definitely parse any sort of non standard SCSS or Sass code and if you use any platform specific code in the file it will almost definitely produce a parse error. Sass-lint will not be moving to support any use of non standard language outside of the Sass spec.
+
+
 ### Contributing
 
 Contributions, suggestions and fixes are more than welcome.

--- a/lib/constants.coffee
+++ b/lib/constants.coffee
@@ -1,0 +1,3 @@
+module.exports =
+  SASSLINT_DOC_URL: 'https://github.com/sasstools/sass-lint/tree/master/docs/rules',
+  VALID_SYNTAXES: ['scss', 'sass']

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -1,6 +1,35 @@
+path = require 'path'
+{SASSLINT_DOC_URL, VALID_SYNTAXES} = require './constants.coffee'
+
 module.exports =
 
-  # Constructs the rule URI from the rule ID provided
+  ###*
+   * Function to construct the rule URI from the rule ID provided
+   * @param {string} ruleId - The rule name / id
+   * @return {string} The rule URL
+   ###
   getRuleURI: (ruleId) ->
-    sassLintDocs = 'https://github.com/sasstools/sass-lint/tree/master/docs/rules'
-    return sassLintDocs + '/' + ruleId + '.md'
+    return SASSLINT_DOC_URL + '/' + ruleId + '.md'
+
+  ###*
+   * Function to check a file base / extension for valid extensions to use with sass-lint
+   * @param {string} syntax - The syntax to check
+   * @return {boolean} Whether or not the syntax is valid for sass-lint
+   ###
+  isValidSyntax: (syntax) ->
+    return VALID_SYNTAXES.indexOf(syntax) isnt -1
+
+  ###*
+   * Function to check a file base / extension for valid extensions to use with sass-lint
+   * @param {string} filePath - The filepath to check
+   * @return {string} The syntax we wish to pass to sass-lint
+   ###
+  getFileSyntax: (filePath) ->
+    existingSyntax = path.extname(filePath).slice(1)
+    if @isValidSyntax(existingSyntax) is false
+      base = path.parse(filePath).base.split('.')
+      syntax = (item for item in base when @isValidSyntax(item))
+      if syntax.length
+        return syntax[0]
+
+    return existingSyntax

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -75,7 +75,7 @@ module.exports =
   provideLinter: ->
     {find} = require 'atom-linter'
     globule = require 'globule'
-    {getRuleURI} = require './helpers'
+    helpers = require './helpers'
 
     provider =
       name: 'sass-lint'
@@ -136,7 +136,7 @@ module.exports =
           if globule.isMatch(compiledConfig.files.include, relativePath) and not globule.isMatch(compiledConfig.files.ignore, relativePath)
             result = linter.lintText({
               text: editor.getText(),
-              format: path.extname(filePath).slice(1),
+              format: helpers.getFileSyntax(filePath),
               filename: filePath
             }, {}, config)
         catch error
@@ -169,7 +169,7 @@ module.exports =
           line = if msg.line then msg.line - 1 else 0
           col = if msg.column then msg.column - 1 else 0
           text = if msg.message then ' ' + msg.message else 'Unknown Error'
-          ruleHref = getRuleURI(msg.ruleId)
+          ruleHref = helpers.getRuleURI(msg.ruleId)
           html = '<a href="'+ ruleHref + '" class="badge badge-flexible sass-lint">' + msg.ruleId + '</a>' + text
 
           result = {

--- a/spec/helpers-spec.js
+++ b/spec/helpers-spec.js
@@ -1,0 +1,48 @@
+'use babel';
+
+import { SASSLINT_DOC_URL } from '../lib/constants.coffee';
+
+const helpers = require('../lib/helpers.coffee');
+
+describe('helpers', () => {
+  describe('getRuleURI', () => {
+    it('should return the correct rule URL', () => {
+      const ruleId = 'no-ids';
+      const result = helpers.getRuleURI(ruleId);
+
+      expect(result).toEqual(`${SASSLINT_DOC_URL}/${ruleId}.md`);
+    });
+  });
+
+  describe('isValidSyntax', () => {
+    it('should return true if a supported syntax is passed', () => {
+      expect(helpers.isValidSyntax('scss')).toEqual(true);
+    });
+
+    it('should return false if a supported syntax is not passed', () => {
+      expect(helpers.isValidSyntax('html')).toEqual(false);
+    });
+  });
+
+  describe('getFileSyntax', () => {
+    it('it should return scss if a scss filename is provided', () => {
+      expect(helpers.getFileSyntax('test/file.scss')).toEqual('scss');
+    });
+
+    it('it should return sass if a sass filename is provided', () => {
+      expect(helpers.getFileSyntax('test/file.sass')).toEqual('sass');
+    });
+
+    it('it should return scss if a scss.liquid filename is provided', () => {
+      expect(helpers.getFileSyntax('test/file.scss.liquid')).toEqual('scss');
+    });
+
+    it('it should return sass if a sass.liquid filename is provided', () => {
+      expect(helpers.getFileSyntax('test/file.sass.liquid')).toEqual('sass');
+    });
+
+    it('it should return html if a html filename is provided', () => {
+      expect(helpers.getFileSyntax('test/file.html')).toEqual('html');
+    });
+  });
+});


### PR DESCRIPTION
Allows files with extra extensions to be passed to the linter such as 'file.scss.liquid' default behaviour is still maintained for unknown syntaxes.

This DOES NOT mean that the AST sass-lint uses will be able to handle your custom file type and any platform specific content you add to these files and in most cases will fail if it encounters invalid non standard scss or Sass code.

Also prepares v1.5.0
Fixes #90 