### PR TITLE
Add option for resolving paths relative to config file instead of project root

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -12,7 +12,7 @@ module.exports =
     resolvePathsRelativeToConfig:
       title: 'Resolve paths in configuration relative to config file'
       type: 'boolean'
-      description: '(and not relative to project root)'
+      description: 'Instead of the default where paths are resolved relative to the project root'
       default: 'false'
     configFile:
       title: '.sass-lint.yml Config File'

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -49,6 +49,7 @@ module.exports =
     @subs.add atom.config.observe 'linter-sass-lint.resolvePathsRelativeToConfig',
       (resolvePathsRelativeToConfig) =>
         @resolvePathsRelativeToConfig = resolvePathsRelativeToConfig
+
   deactivate: ->
     @subs.dispose()
 


### PR DESCRIPTION
This PR adds an option for resolving paths relative to the config file location instead of the project root and resolves issue AtomLinter/linter-sass-lint#99
