### PR TITLE
Force new sass-lint version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.6.1
+- Force update to sass-lint 1.8.0 due to the high number of fixes and also AST fixes
+
 ## 1.6.0
 - Adds `resolvePathsRelativeToConfig` to the config options to allow paths to be resolved relative to your config file rather than project root. Thanks to [@DirtyHairy](https://github.com/DirtyHairy)
 - The usual third party package updates

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "atom-package-deps": "4.0.1",
     "consistent-env": "^1.0.1",
     "globule": "^1.0.0",
-    "sass-lint": "^1.7.0"
+    "sass-lint": "^1.8.0"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
Just updating minimum sass-lint dependency as sass-lint 1.8 includes a lot of fixes and AST updates