### PR TITLE
Update eslint-plugin-import to v1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "coffeelint": "^1.14.2",
     "eslint": "3.6.0",
     "eslint-config-airbnb-base": "^8.0.0",
-    "eslint-plugin-import": "^1.14.0"
+    "eslint-plugin-import": "^1.16.0"
   },
   "eslintConfig": {
     "extends": "airbnb-base",


### PR DESCRIPTION
Minimum version to satisfy the `peerDependency` of `eslint-config-airbnb-base`.