### PR TITLE
Revert "Update eslint-plugin-import to version 2.0.1 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "coffeelint": "^1.14.2",
     "eslint": "^3.7.1",
     "eslint-config-airbnb-base": "^8.0.0",
-    "eslint-plugin-import": "^2.0.1"
+    "eslint-plugin-import": "^1.16.0"
   },
   "eslintConfig": {
     "extends": "airbnb-base",


### PR DESCRIPTION
Reverts AtomLinter/linter-sass-lint#156

This shouldn't have been merged yet as it breaks the `peerDependency` of `eslint-config-airbnb-base@8`.