### PR TITLE
Asyncify the specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "coffeelint": "^1.16.0",
     "eslint": "^4.6.0",
     "eslint-config-airbnb-base": "^12.0.0",
-    "eslint-plugin-import": "^2.7.0"
+    "eslint-plugin-import": "^2.7.0",
+    "jasmine-fix": "^1.3.0"
   },
   "eslintConfig": {
     "extends": "airbnb-base",

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -1,8 +1,14 @@
 {
-  "globals": {
-    "waitsForPromise": true
-  },
   "env": {
+    "atomtest": true,
     "jasmine": true
+  },
+  "rules": {
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true
+      }
+    ]
   }
 }

--- a/spec/helpers-spec.js
+++ b/spec/helpers-spec.js
@@ -1,5 +1,7 @@
 'use babel';
 
+// eslint-disable-next-line no-unused-vars
+import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
 import { SASSLINT_DOC_URL } from '../lib/constants.coffee';
 
 const helpers = require('../lib/helpers.coffee');
@@ -50,13 +52,8 @@ describe('helpers', () => {
   describe('getRootDir', () => {
     let editor = null;
 
-    beforeEach(() => {
-      waitsForPromise(() => (
-        atom.workspace.open(`${__dirname}/fixtures/files/failure.scss`)
-          .then((openEditor) => {
-            editor = openEditor;
-          })
-      ));
+    beforeEach(async () => {
+      editor = await atom.workspace.open(`${__dirname}/fixtures/files/failure.scss`);
     });
 
     it('should return null if the file isn\'t within the currently open project', () => {
@@ -75,13 +72,8 @@ describe('helpers', () => {
   describe('getRootDirConfig', () => {
     let editor = null;
 
-    beforeEach(() => {
-      waitsForPromise(() => (
-        atom.workspace.open(`${__dirname}/fixtures/files/failure.scss`)
-          .then((openEditor) => {
-            editor = openEditor;
-          })
-      ));
+    beforeEach(async () => {
+      editor = await atom.workspace.open(`${__dirname}/fixtures/files/failure.scss`);
     });
 
     it('should return null if no root directory is specified', () => {

--- a/spec/linter-sass-lint-path-options-spec.js
+++ b/spec/linter-sass-lint-path-options-spec.js
@@ -1,5 +1,7 @@
 'use babel';
 
+// eslint-disable-next-line no-unused-vars
+import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
 import { join } from 'path';
 
 const { lint } = require('../lib/main.coffee').provideLinter();
@@ -8,34 +10,27 @@ const failurePath = join(__dirname, 'fixtures', 'files', 'failure.scss');
 const configFile = join(__dirname, 'fixtures', 'config', '.sass-lint.yml');
 
 describe('The sass-lint provider for Linter - path options', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     atom.workspace.destroyActivePaneItem();
-    waitsForPromise(() => {
-      atom.packages.activatePackage('linter-sass-lint');
-      return atom.packages.activatePackage('language-sass');
-    });
+    await atom.packages.activatePackage('language-sass');
+    await atom.packages.activatePackage('linter-sass-lint');
   });
 
   describe('checks failure.scss, expects a message and', () => {
-    let editor = null;
+    let messages = null;
 
-    beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configFile', configFile);
-        atom.config.set('linter-sass-lint.globalSassLint', true);
-        return atom.workspace.open(failurePath).then((openEditor) => {
-          editor = openEditor;
-        });
-      });
+    beforeEach(async () => {
+      atom.config.set('linter-sass-lint.configFile', configFile);
+      atom.config.set('linter-sass-lint.globalSassLint', true);
+      const editor = await atom.workspace.open(failurePath);
+      messages = await lint(editor);
     });
 
     it('lints the file with the globally installed sass-lint', () => {
-      const messages = lint(editor);
       expect(messages.length).toBeGreaterThan(0);
     });
 
     it('verifies the first message', () => {
-      const messages = lint(editor);
       const slDocUrl = 'https://github.com/sasstools/sass-lint/tree/master/docs/rules/no-ids.md';
       const attributes = `href="${slDocUrl}" class="badge badge-flexible sass-lint"`;
       const warningMarkup = `<a ${attributes}>no-ids</a>`;
@@ -49,7 +44,6 @@ describe('The sass-lint provider for Linter - path options', () => {
     });
 
     it('verifies the second message', () => {
-      const messages = lint(editor);
       const slDocUrl = 'https://github.com/sasstools/sass-lint/tree/master/docs/rules/no-color-literals.md';
       const attributes = `href="${slDocUrl}" class="badge badge-flexible sass-lint"`;
       const warningMarkup = `<a ${attributes}>no-color-literals</a>`;

--- a/spec/linter-sass-lint-sass-spec.js
+++ b/spec/linter-sass-lint-sass-spec.js
@@ -1,5 +1,7 @@
 'use babel';
 
+// eslint-disable-next-line no-unused-vars
+import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
 import { join } from 'path';
 
 const { lint } = require('../lib/main.coffee').provideLinter();
@@ -10,33 +12,26 @@ const passPath = join(__dirname, 'fixtures', 'files', 'pass.scss');
 const configFile = join(__dirname, 'fixtures', 'config', '.sass-lint.yml');
 
 describe('The sass-lint provider for Linter - sass', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     atom.workspace.destroyActivePaneItem();
-    waitsForPromise(() => {
-      atom.packages.activatePackage('linter-sass-lint');
-      return atom.packages.activatePackage('language-sass');
-    });
+    await atom.packages.activatePackage('language-sass');
+    await atom.packages.activatePackage('linter-sass-lint');
   });
 
   describe('checks failure.sass and', () => {
-    let editor = null;
+    let messages = null;
 
-    beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configFile', configFile);
-        return atom.workspace.open(failurePath).then((openEditor) => {
-          editor = openEditor;
-        });
-      });
+    beforeEach(async () => {
+      atom.config.set('linter-sass-lint.configFile', configFile);
+      const editor = await atom.workspace.open(failurePath);
+      messages = await lint(editor);
     });
 
     it('finds at least one message', () => {
-      const messages = lint(editor);
       expect(messages.length).toBeGreaterThan(0);
     });
 
     it('verifies the first message', () => {
-      const messages = lint(editor);
       const slDocUrl = 'https://github.com/sasstools/sass-lint/tree/master/docs/rules/no-ids.md';
       const attributes = `href="${slDocUrl}" class="badge badge-flexible sass-lint"`;
       const warningMarkup = `<a ${attributes}>no-ids</a>`;
@@ -50,7 +45,6 @@ describe('The sass-lint provider for Linter - sass', () => {
     });
 
     it('verifies the second message', () => {
-      const messages = lint(editor);
       const slDocUrl = 'https://github.com/sasstools/sass-lint/tree/master/docs/rules/no-color-literals.md';
       const attributes = `href="${slDocUrl}" class="badge badge-flexible sass-lint"`;
       const warningMarkup = `<a ${attributes}>no-color-literals</a>`;
@@ -65,56 +59,32 @@ describe('The sass-lint provider for Linter - sass', () => {
   });
 
   describe('checks pass.sass and', () => {
-    let editor = null;
+    it('finds nothing wrong with the valid file', async () => {
+      atom.config.set('linter-sass-lint.configFile', configFile);
+      const editor = await atom.workspace.open(passPath);
+      const messages = await lint(editor);
 
-    beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configFile', configFile);
-        return atom.workspace.open(passPath).then((openEditor) => {
-          editor = openEditor;
-        });
-      });
-    });
-
-    it('finds nothing wrong with the valid file', () => {
-      const messages = lint(editor);
       expect(messages.length).toBe(0);
     });
   });
 
   describe('opens ignored.sass and', () => {
-    let editor = null;
+    it('ignores the file and reports no warnings', async () => {
+      atom.config.set('linter-sass-lint.configFile', configFile);
+      const editor = await atom.workspace.open(ignoredPath);
+      const messages = await lint(editor);
 
-    beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configFile', configFile);
-        return atom.workspace.open(ignoredPath).then((openEditor) => {
-          editor = openEditor;
-        });
-      });
-    });
-
-    it('ignores the file and reports no warnings', () => {
-      const messages = lint(editor);
       expect(messages.length).toBe(0);
     });
   });
 
   describe('opens failure.sass and sets pacakage to not lint if no config file present', () => {
-    let editor = null;
+    it("doesn't lint the file as there's no config file present", async () => {
+      atom.config.set('linter-sass-lint.noConfigDisable', true);
+      atom.config.set('linter-sass-lint.configFile', '');
+      const editor = await atom.workspace.open(failurePath);
+      const messages = await lint(editor);
 
-    beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.noConfigDisable', true);
-        atom.config.set('linter-sass-lint.configFile', '');
-        return atom.workspace.open(failurePath).then((openEditor) => {
-          editor = openEditor;
-        });
-      });
-    });
-
-    it("doesn't lint the file as there's no config file present", () => {
-      const messages = lint(editor);
       expect(messages.length).toBe(0);
     });
   });

--- a/spec/linter-sass-lint-scss-spec.js
+++ b/spec/linter-sass-lint-scss-spec.js
@@ -1,5 +1,7 @@
 'use babel';
 
+// eslint-disable-next-line no-unused-vars
+import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
 import { join } from 'path';
 
 const { lint } = require('../lib/main.coffee').provideLinter();
@@ -10,33 +12,26 @@ const passPath = join(__dirname, 'fixtures', 'files', 'pass.scss');
 const configFile = join(__dirname, 'fixtures', 'config', '.sass-lint.yml');
 
 describe('The sass-lint provider for Linter - scss', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     atom.workspace.destroyActivePaneItem();
-    waitsForPromise(() => {
-      atom.packages.activatePackage('linter-sass-lint');
-      return atom.packages.activatePackage('language-sass');
-    });
+    await atom.packages.activatePackage('linter-sass-lint');
+    await atom.packages.activatePackage('language-sass');
   });
 
   describe('checks failure.scss and', () => {
-    let editor = null;
+    let messages = null;
 
-    beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configFile', configFile);
-        return atom.workspace.open(failurePath).then((openEditor) => {
-          editor = openEditor;
-        });
-      });
+    beforeEach(async () => {
+      atom.config.set('linter-sass-lint.configFile', configFile);
+      const editor = await atom.workspace.open(failurePath);
+      messages = await lint(editor);
     });
 
     it('finds at least one message', () => {
-      const messages = lint(editor);
       expect(messages.length).toBeGreaterThan(0);
     });
 
     it('verifies the first message', () => {
-      const messages = lint(editor);
       const slDocUrl = 'https://github.com/sasstools/sass-lint/tree/master/docs/rules/no-ids.md';
       const attributes = `href="${slDocUrl}" class="badge badge-flexible sass-lint"`;
       const warningMarkup = `<a ${attributes}>no-ids</a>`;
@@ -50,7 +45,6 @@ describe('The sass-lint provider for Linter - scss', () => {
     });
 
     it('verifies the second message', () => {
-      const messages = lint(editor);
       const slDocUrl = 'https://github.com/sasstools/sass-lint/tree/master/docs/rules/no-color-literals.md';
       const attributes = `href="${slDocUrl}" class="badge badge-flexible sass-lint"`;
       const warningMarkup = `<a ${attributes}>no-color-literals</a>`;
@@ -65,56 +59,32 @@ describe('The sass-lint provider for Linter - scss', () => {
   });
 
   describe('checks pass.scss and', () => {
-    let editor = null;
+    it('finds nothing wrong with the valid file', async () => {
+      atom.config.set('linter-sass-lint.configFile', configFile);
+      const editor = await atom.workspace.open(passPath);
+      const messages = await lint(editor);
 
-    beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configFile', configFile);
-        return atom.workspace.open(passPath).then((openEditor) => {
-          editor = openEditor;
-        });
-      });
-    });
-
-    it('finds nothing wrong with the valid file', () => {
-      const messages = lint(editor);
       expect(messages.length).toBe(0);
     });
   });
 
   describe('opens ignored.scss and', () => {
-    let editor = null;
+    it('ignores the file and reports no warnings', async () => {
+      atom.config.set('linter-sass-lint.configFile', configFile);
+      const editor = await atom.workspace.open(ignoredPath);
+      const messages = await lint(editor);
 
-    beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.configFile', configFile);
-        return atom.workspace.open(ignoredPath).then((openEditor) => {
-          editor = openEditor;
-        });
-      });
-    });
-
-    it('ignores the file and reports no warnings', () => {
-      const messages = lint(editor);
       expect(messages.length).toBe(0);
     });
   });
 
   describe('opens failure.scss and sets pacakage to not lint if no config file present', () => {
-    let editor = null;
+    it("doesn't lint the file as there's no config file present", async () => {
+      atom.config.set('linter-sass-lint.noConfigDisable', true);
+      atom.config.set('linter-sass-lint.configFile', '');
+      const editor = await atom.workspace.open(failurePath);
+      const messages = await lint(editor);
 
-    beforeEach(() => {
-      waitsForPromise(() => {
-        atom.config.set('linter-sass-lint.noConfigDisable', true);
-        atom.config.set('linter-sass-lint.configFile', '');
-        return atom.workspace.open(failurePath).then((openEditor) => {
-          editor = openEditor;
-        });
-      });
-    });
-
-    it("doesn't lint the file as there's no config file present", () => {
-      const messages = lint(editor);
       expect(messages.length).toBe(0);
     });
   });


### PR DESCRIPTION
Bring in `jasmine-fix` to allow the use of `async`/`await` in the specs and refactor them to take advantage of this.

Note that although this provider currently doesn't utilize an asynchronous `lint()`, the specs will now support that if/when it does.