### PR TITLE
update: update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "atom-package-deps": "^4.6.0",
     "consistent-env": "^1.3.1",
     "globule": "^1.2.0",
-    "sass-lint": "1.12.0"
+    "sass-lint": "^1.12.0"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
change `sass-lint` dependencies

When enter `background-image: url()`, It will make Atom crash:
```scss
.class {
  background-image: url()
}
```

[gonzales-pe](https://github.com/tonyganch/gonzales-pe) fixed it on `4.2.3`.
and `sass-lint`depend on it.